### PR TITLE
Fix bug in List.last<T>.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,6 +3,7 @@
 ## Next
 
 * **Breaking:** Enable persistence of `Random` and `AsyncRandom` state in stable memory (#329).
+* Fix a bug in `List.last<T>` (#336). 
 
 ## 0.5.0
 

--- a/src/List.mo
+++ b/src/List.mo
@@ -1287,14 +1287,13 @@ module {
   /// Space: `O(1)`
   public func last<T>(list : List<T>) : ?T {
     let e = list.elementIndex;
-    if (e > 0) {
-      switch (list.blocks[list.blockIndex][e - 1]) {
-        case null { Prim.trap(INTERNAL_ERROR) };
-        case e { return e }
-      }
-    };
-    let b = list.blockIndex;
-    if (b == 1) null else list.blocks[b - 1][0]
+    if (e > 0) return list.blocks[list.blockIndex][e - 1];
+
+    let b = list.blockIndex - 1 : Nat;
+    if (b == 0) null else {
+      let block = list.blocks[b];
+      block[block.size() - 1]
+    }
   };
 
   /// Applies `f` to each element in `list`.

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -239,8 +239,14 @@ run(
   )
 );
 
+// Test last and first
+assert List.last(list) == null;
+assert List.first(list) == null;
+
 for (i in Nat.rangeInclusive(0, n)) {
-  List.add(list, i)
+  List.add(list, i);
+  assert List.last(list) == ?i;
+  assert List.first(list) == ?0;
 };
 
 run(
@@ -284,6 +290,11 @@ run(
         "last of len 1",
         List.last(List.repeat<Nat>(1, 1)),
         M.equals(T.optional(T.natTestable, ?1))
+      ),
+      test(
+        "last of 6",
+        List.last(List.fromArray<Nat>([0, 1, 2, 3, 4, 5])),
+        M.equals(T.optional(T.natTestable, ?5))
       ),
       test(
         "last empty",

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -246,7 +246,7 @@ assert List.first(list) == null;
 for (i in Nat.rangeInclusive(0, n)) {
   List.add(list, i);
   assert List.last(list) == ?i;
-  assert List.first(list) == ?0;
+  assert List.first(list) == ?0
 };
 
 run(


### PR DESCRIPTION
There is a bug in List.last<T>: when elementIndex is zero we should look at the last element in the previous data block, not first. Probability to encounter this bug in 1 / sqrt(n). Optimized and cleaned up code. Added stronger tests.