### PR TITLE
Add `fromArray()` and `toArray()` to `Queue` and `pure/Queue`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -3,7 +3,8 @@
 ## Next
 
 * **Breaking:** Enable persistence of `Random` and `AsyncRandom` state in stable memory (#329).
-* Added `explode` to `Int16`/`32`/`64`, `Nat16`/`32`/`64`, slicing fixed-length numbers into constituent bytes (#346).
+* Add `explode()` to `Int16`/`32`/`64`, `Nat16`/`32`/`64`, slicing fixed-length numbers into constituent bytes (#346).
+* Add `fromArray()` and `toArray()` to `Queue` and `pure/Queue`.
 * Fix a bug in `List.last<T>` (#336). 
 * Fix a typo in the `VarArray` documentation (#338).
 * Perf: Uses the new Array_tabulateVar primitive to speed up various function in VarArray (#334)

--- a/Changelog.md
+++ b/Changelog.md
@@ -4,7 +4,7 @@
 
 * **Breaking:** Enable persistence of `Random` and `AsyncRandom` state in stable memory (#329).
 * Add `explode()` to `Int16`/`32`/`64`, `Nat16`/`32`/`64`, slicing fixed-length numbers into constituent bytes (#346).
-* Add `fromArray()` and `toArray()` to `Queue` and `pure/Queue`.
+* Add `fromArray()` and `toArray()` to `Queue` and `pure/Queue` (#349).
 * Fix a bug in `List.last<T>` (#336). 
 * Fix a typo in the `VarArray` documentation (#338).
 * Perf: Uses the new Array_tabulateVar primitive to speed up various function in VarArray (#334)

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,7 +7,7 @@
 * Add `fromArray()` and `toArray()` to `Queue` and `pure/Queue` (#349).
 * Fix a bug in `List.last<T>` (#336). 
 * Fix a typo in the `VarArray` documentation (#338).
-* Perf: Uses the new Array_tabulateVar primitive to speed up various function in VarArray (#334)
+* Perf: Uses the new `Array_tabulateVar` primitive to speed up various function in `VarArray` (#334).
 * Add `Text.reverse()` (#351).
 
 ## 0.5.0

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -483,7 +483,7 @@ module {
     let iter = values(queue);
     Array.tabulate<T>(queue.size, func(i) {
       switch (iter.next()) {
-        case null { Prim.trap("Queue.toArray: internal error") };
+        case null { Prim.trap("Queue.toArray: unexpected end of iterator") };
         case (?value) { value }
       }
     })

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -481,12 +481,15 @@ module {
   /// `n` denotes the number of elements stored in the queue.
   public func toArray<T>(queue : Queue<T>) : [T] {
     let iter = values(queue);
-    Array.tabulate<T>(queue.size, func(i) {
-      switch (iter.next()) {
-        case null { Prim.trap("Queue.toArray: unexpected end of iterator") };
-        case (?value) { value }
+    Array.tabulate<T>(
+      queue.size,
+      func(i) {
+        switch (iter.next()) {
+          case null { Prim.trap("Queue.toArray: unexpected end of iterator") };
+          case (?value) { value }
+        }
       }
-    })
+    )
   };
 
   /// Returns an iterator over the elements in the queue.

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -485,7 +485,7 @@ module {
       queue.size,
       func(i) {
         switch (iter.next()) {
-          case null { Prim.trap("Queue.toArray: unexpected end of iterator") };
+          case null { Prim.trap("Queue.toArray(): unexpected end of iterator") };
           case (?value) { value }
         }
       }

--- a/src/Queue.mo
+++ b/src/Queue.mo
@@ -33,6 +33,8 @@ import PureQueue "pure/Queue";
 import Iter "Iter";
 import Order "Order";
 import Types "Types";
+import Array "Array";
+import Prim "mo:⛔";
 
 module {
   public type Queue<T> = Types.Queue.Queue<T>;
@@ -432,6 +434,59 @@ module {
       pushBack(queue, element)
     };
     queue
+  };
+
+  /// Creates a new queue from an array.
+  /// Elements appear in the same order as in the array.
+  ///
+  /// Example:
+  /// ```motoko
+  /// import Queue "mo:core/Queue";
+  ///
+  /// persistent actor {
+  ///   let queue = Queue.fromArray<Text>(["A", "B", "C"]);
+  ///   assert Queue.size(queue) == 3;
+  ///   assert Queue.peekFront(queue) == ?"A";
+  /// }
+  /// ```
+  ///
+  /// Runtime: O(n)
+  /// Space: O(n)
+  /// `n` denotes the number of elements stored in the array.
+  public func fromArray<T>(array : [T]) : Queue<T> {
+    let queue = empty<T>();
+    for (element in array.vals()) {
+      pushBack(queue, element)
+    };
+    queue
+  };
+
+  /// Creates a new immutable array containing all elements from the queue.
+  /// Elements appear in the same order as in the queue (front to back).
+  ///
+  /// Example:
+  /// ```motoko
+  /// import Queue "mo:core/Queue";
+  /// import Array "mo:core/Array";
+  ///
+  /// persistent actor {
+  ///   let queue = Queue.fromArray<Text>(["A", "B", "C"]);
+  ///   let array = Queue.toArray(queue);
+  ///   assert array == ["A", "B", "C"];
+  /// }
+  /// ```
+  ///
+  /// Runtime: O(n)
+  /// Space: O(n)
+  /// `n` denotes the number of elements stored in the queue.
+  public func toArray<T>(queue : Queue<T>) : [T] {
+    let iter = values(queue);
+    Array.tabulate<T>(queue.size, func(i) {
+      switch (iter.next()) {
+        case null { Prim.trap("Queue.toArray: internal error") };
+        case (?value) { value }
+      }
+    })
   };
 
   /// Returns an iterator over the elements in the queue.

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -352,7 +352,7 @@ module {
     let iter = values(queue);
     Array.tabulate<T>(queue.1, func(i) {
       switch (iter.next()) {
-        case null { Prim.trap("Queue.toArray: internal error") };
+        case null { Prim.trap("pure/Queue.toArray: unexpected end of iterator") };
         case (?value) { value }
       }
     })

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -32,6 +32,8 @@ import Iter "../Iter";
 import List "List";
 import Order "../Order";
 import Types "../Types";
+import Array "../Array";
+import Prim "mo:⛔";
 
 module {
   type List<T> = Types.Pure.List<T>;
@@ -307,6 +309,53 @@ module {
   public func fromIter<T>(iter : Iter.Iter<T>) : Queue<T> {
     let list = List.fromIter iter;
     check(list, List.size list, null)
+  };
+
+  /// Create a queue from an array.
+  /// Elements appear in the same order as in the array.
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// persistent actor {
+  ///   let queue = Queue.fromArray<Text>(["A", "B", "C"]);
+  ///   assert Queue.size(queue) == 3;
+  ///   assert Queue.peekFront(queue) == ?"A";
+  /// }
+  /// ```
+  ///
+  /// Runtime: O(size)
+  ///
+  /// Space: O(size)
+  public func fromArray<T>(array : [T]) : Queue<T> {
+    let list = List.fromArray array;
+    check(list, array.size(), null)
+  };
+
+  /// Create an immutable array from a queue.
+  /// Elements appear in the same order as in the queue (front to back).
+  ///
+  /// Example:
+  /// ```motoko include=import
+  /// import Array "mo:core/Array";
+  ///
+  /// persistent actor {
+  ///   let queue = Queue.fromArray<Text>(["A", "B", "C"]);
+  ///   let array = Queue.toArray(queue);
+  ///   assert array == ["A", "B", "C"];
+  /// }
+  /// ```
+  ///
+  /// Runtime: O(size)
+  ///
+  /// Space: O(size)
+  public func toArray<T>(queue : Queue<T>) : [T] {
+    let iter = values(queue);
+    Array.tabulate<T>(queue.1, func(i) {
+      switch (iter.next()) {
+        case null { Prim.trap("Queue.toArray: internal error") };
+        case (?value) { value }
+      }
+    })
   };
 
   /// Convert a queue to an iterator of its elements in front-to-back order.

--- a/src/pure/Queue.mo
+++ b/src/pure/Queue.mo
@@ -350,12 +350,17 @@ module {
   /// Space: O(size)
   public func toArray<T>(queue : Queue<T>) : [T] {
     let iter = values(queue);
-    Array.tabulate<T>(queue.1, func(i) {
-      switch (iter.next()) {
-        case null { Prim.trap("pure/Queue.toArray: unexpected end of iterator") };
-        case (?value) { value }
+    Array.tabulate<T>(
+      queue.1,
+      func(i) {
+        switch (iter.next()) {
+          case null {
+            Prim.trap("pure/Queue.toArray: unexpected end of iterator")
+          };
+          case (?value) { value }
+        }
       }
-    })
+    )
   };
 
   /// Convert a queue to an iterator of its elements in front-to-back order.

--- a/test/Queue.test.mo
+++ b/test/Queue.test.mo
@@ -81,7 +81,7 @@ suite(
     );
 
     test(
-      "vals",
+      "values",
       func() {
         assert Iter.toArray(Queue.values(Queue.empty<Nat>())) == []
       }
@@ -605,6 +605,86 @@ suite(
         };
         assert counter == numberOfSteps;
         expect.nat(Queue.size(queue)).equal((numberOfSteps + 1) / 2)
+      }
+    )
+  }
+);
+
+suite(
+  "fromArray",
+  func() {
+    test(
+      "empty array",
+      func() {
+        let queue = Queue.fromArray<Nat>([]);
+        assert Queue.isEmpty(queue);
+        assert Queue.size(queue) == 0
+      }
+    );
+
+    test(
+      "single element",
+      func() {
+        let queue = Queue.fromArray<Nat>([42]);
+        assert Queue.size(queue) == 1;
+        assert Queue.peekFront(queue) == ?42;
+        assert Queue.peekBack(queue) == ?42
+      }
+    );
+
+    test(
+      "multiple elements",
+      func() {
+        let queue = Queue.fromArray<Nat>([1, 2, 3]);
+        assert Queue.size(queue) == 3;
+        assert Queue.peekFront(queue) == ?1;
+        assert Queue.peekBack(queue) == ?3;
+        assert Queue.popFront(queue) == ?1;
+        assert Queue.popFront(queue) == ?2;
+        assert Queue.popFront(queue) == ?3;
+        assert Queue.isEmpty(queue)
+      }
+    )
+  }
+);
+
+suite(
+  "toArray",
+  func() {
+    test(
+      "empty queue",
+      func() {
+        let queue = Queue.empty<Nat>();
+        let array = Queue.toArray(queue);
+        assert array == []
+      }
+    );
+
+    test(
+      "single element",
+      func() {
+        let queue = Queue.singleton<Nat>(42);
+        let array = Queue.toArray(queue);
+        assert array == [42]
+      }
+    );
+
+    test(
+      "multiple elements",
+      func() {
+        let queue = Queue.fromArray<Nat>([1, 2, 3]);
+        let array = Queue.toArray(queue);
+        assert array == [1, 2, 3]
+      }
+    );
+
+    test(
+      "round trip",
+      func() {
+        let original = [1, 2, 3, 4, 5];
+        let queue = Queue.fromArray<Nat>(original);
+        let result = Queue.toArray(queue);
+        assert result == original
       }
     )
   }

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -573,4 +573,98 @@ suite(
       }
     )
   }
+);
+
+suite(
+  "fromArray",
+  func() {
+    test(
+      "empty array",
+      func() {
+        let queue = Queue.fromArray<Nat>([]);
+        assert Queue.isEmpty(queue);
+        assert Queue.size(queue) == 0
+      }
+    );
+
+    test(
+      "single element",
+      func() {
+        let queue = Queue.fromArray<Nat>([42]);
+        assert Queue.size(queue) == 1;
+        assert Queue.peekFront(queue) == ?42;
+        assert Queue.peekBack(queue) == ?42
+      }
+    );
+
+    test(
+      "multiple elements",
+      func() {
+        let queue = Queue.fromArray<Nat>([1, 2, 3]);
+        assert Queue.size(queue) == 3;
+        assert Queue.peekFront(queue) == ?1;
+        assert Queue.peekBack(queue) == ?3;
+        
+        switch (Queue.popFront(queue)) {
+          case null assert false;
+          case (?(1, rest1)) {
+            switch (Queue.popFront(rest1)) {
+              case null assert false;
+              case (?(2, rest2)) {
+                switch (Queue.popFront(rest2)) {
+                  case null assert false;
+                  case (?(3, rest3)) {
+                    assert Queue.isEmpty(rest3)
+                  }
+                }
+              }
+            }
+          };
+          case _ assert false
+        }
+      }
+    )
+  }
+);
+
+suite(
+  "toArray",
+  func() {
+    test(
+      "empty queue",
+      func() {
+        let queue = Queue.empty<Nat>();
+        let array = Queue.toArray(queue);
+        assert array == []
+      }
+    );
+
+    test(
+      "single element",
+      func() {
+        let queue = Queue.singleton<Nat>(42);
+        let array = Queue.toArray(queue);
+        assert array == [42]
+      }
+    );
+
+    test(
+      "multiple elements",
+      func() {
+        let queue = Queue.fromArray<Nat>([1, 2, 3]);
+        let array = Queue.toArray(queue);
+        assert array == [1, 2, 3]
+      }
+    );
+
+    test(
+      "round trip",
+      func() {
+        let original = [1, 2, 3, 4, 5];
+        let queue = Queue.fromArray<Nat>(original);
+        let result = Queue.toArray(queue);
+        assert result == original
+      }
+    )
+  }
 )

--- a/test/pure/Queue.test.mo
+++ b/test/pure/Queue.test.mo
@@ -604,7 +604,7 @@ suite(
         assert Queue.size(queue) == 3;
         assert Queue.peekFront(queue) == ?1;
         assert Queue.peekBack(queue) == ?3;
-        
+
         switch (Queue.popFront(queue)) {
           case null assert false;
           case (?(1, rest1)) {

--- a/validation/api/api.lock.json
+++ b/validation/api/api.lock.json
@@ -916,6 +916,7 @@
       "public func filter<T>(queue : Queue<T>, criterion : T -> Bool) : Queue<T>",
       "public func filterMap<T, U>(queue : Queue<T>, project : T -> ?U) : Queue<U>",
       "public func forEach<T>(queue : Queue<T>, operation : T -> ())",
+      "public func fromArray<T>(array : [T]) : Queue<T>",
       "public func fromIter<T>(iter : Iter.Iter<T>) : Queue<T>",
       "public func fromPure<T>(pureQueue : PureQueue.Queue<T>) : Queue<T>",
       "public func isEmpty<T>(queue : Queue<T>) : Bool",
@@ -929,6 +930,7 @@
       "public type Queue<T>",
       "public func singleton<T>(element : T) : Queue<T>",
       "public func size<T>(queue : Queue<T>) : Nat",
+      "public func toArray<T>(queue : Queue<T>) : [T]",
       "public func toPure<T>(queue : Queue<T>) : PureQueue.Queue<T>",
       "public func toText<T>(queue : Queue<T>, format : T -> Text) : Text",
       "public func values<T>(queue : Queue<T>) : Iter.Iter<T>"
@@ -1359,6 +1361,7 @@
       "public func filter<T>(queue : Queue<T>, predicate : T -> Bool) : Queue<T>",
       "public func filterMap<T, U>(queue : Queue<T>, f : T -> ?U) : Queue<U>",
       "public func forEach<T>(queue : Queue<T>, f : T -> ())",
+      "public func fromArray<T>(array : [T]) : Queue<T>",
       "public func fromIter<T>(iter : Iter.Iter<T>) : Queue<T>",
       "public func isEmpty<T>(queue : Queue<T>) : Bool",
       "public func map<T1, T2>(queue : Queue<T1>, f : T1 -> T2) : Queue<T2>",
@@ -1372,6 +1375,7 @@
       "public func reverse<T>(queue : Queue<T>) : Queue<T>",
       "public func singleton<T>(item : T) : Queue<T>",
       "public func size<T>(queue : Queue<T>) : Nat",
+      "public func toArray<T>(queue : Queue<T>) : [T]",
       "public func toText<T>(queue : Queue<T>, f : T -> Text) : Text",
       "public func values<T>(queue : Queue<T>) : Iter.Iter<T>"
     ]


### PR DESCRIPTION
Motivated from writing data structure migration code examples and noticing this gap in the API.