### PR TITLE
Add missing `AsyncRandom` methods

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Next
 
-* Perf: Made `Nat.toText()` slightly more performant (#358).
+* Make `Nat.toText()` slightly more performant (#358).
+* Add `uniform64()`, `nat64()`, `natRange()`, and `intRange()` to `AsyncRandom` class (#360).
 
 ## 0.6.0
 

--- a/src/Random.mo
+++ b/src/Random.mo
@@ -330,6 +330,61 @@ module {
       byte
     };
 
+    // Helper function which returns a uniformly sampled `Nat64` in the range `[0, max]`.
+    // Uses rejection sampling to ensure uniform distribution even when the range
+    // doesn't divide evenly into 2^64. This avoids modulo bias that would occur
+    // from simply taking the modulo of a random 64-bit number.
+    func uniform64(max : Nat64) : async* Nat64 {
+      if (max == 0) {
+        return 0
+      };
+      if (max == Nat64.maxValue) {
+        return await* nat64()
+      };
+      let toExclusive = max + 1;
+      // 2^64 - (2^64 % toExclusive) = (2^64-1) - (2^64-1 % toExclusive):
+      let cutoff = Nat64.maxValue - (Nat64.maxValue % toExclusive);
+      // 2^64 / toExclusive, with toExclusive > 1:
+      let multiple = Nat64.fromNat(/* 2^64 */ 0x10000000000000000 / Nat64.toNat(toExclusive));
+      loop {
+        // Build up a random Nat64 from bytes
+        var number = await* nat64();
+        // If number is below cutoff, we can use it
+        if (number < cutoff) {
+          // Scale down to desired range
+          return number / multiple
+        };
+        // Otherwise reject and try again
+      }
+    };
+
+    /// Random `Nat64` value in the range [0, 2^64).
+    public func nat64() : async* Nat64 {
+      (Nat64.fromNat(Nat8.toNat(await* nat8())) << 56) | (Nat64.fromNat(Nat8.toNat(await* nat8())) << 48) | (Nat64.fromNat(Nat8.toNat(await* nat8())) << 40) | (Nat64.fromNat(Nat8.toNat(await* nat8())) << 32) | (Nat64.fromNat(Nat8.toNat(await* nat8())) << 24) | (Nat64.fromNat(Nat8.toNat(await* nat8())) << 16) | (Nat64.fromNat(Nat8.toNat(await* nat8())) << 8) | Nat64.fromNat(Nat8.toNat(await* nat8()))
+    };
+
+    /// Random `Nat64` value in the range [fromInclusive, toExclusive).
+    public func nat64Range(fromInclusive : Nat64, toExclusive : Nat64) : async* Nat64 {
+      if (fromInclusive >= toExclusive) {
+        Runtime.trap("AsyncRandom.nat64Range(): fromInclusive >= toExclusive")
+      };
+      (await* uniform64(toExclusive - fromInclusive - 1)) + fromInclusive
+    };
+
+    /// Random `Nat` value in the range [fromInclusive, toExclusive).
+    public func natRange(fromInclusive : Nat, toExclusive : Nat) : async* Nat {
+      if (fromInclusive >= toExclusive) {
+        Runtime.trap("AsyncRandom.natRange(): fromInclusive >= toExclusive")
+      };
+      Nat64.toNat(await* uniform64(Nat64.fromNat(toExclusive - fromInclusive - 1))) + fromInclusive
+    };
+
+    /// Random `Int` value in the range [fromInclusive, toExclusive).
+    public func intRange(fromInclusive : Int, toExclusive : Int) : async* Int {
+      let range = Nat.fromInt(toExclusive - fromInclusive - 1);
+      Nat64.toNat(await* uniform64(Nat64.fromNat(range))) + fromInclusive
+    };
+
   };
 
   // Derived from https://github.com/research-ag/prng

--- a/test/Random.async.test.mo
+++ b/test/Random.async.test.mo
@@ -1,0 +1,630 @@
+import Random "../src/Random";
+import Nat8 "../src/Nat8";
+import Nat "../src/Nat";
+import Nat64 "../src/Nat64";
+import Array "../src/Array";
+import Blob "../src/Blob";
+import { suite; test; expect } = "mo:test/async";
+
+await suite(
+  "Random.emptyState() and AsyncRandom state management",
+  func() : async () {
+    await test(
+      "emptyState() creates proper initial state",
+      func() : async () {
+        let state = Random.emptyState();
+
+        // Verify initial state values
+        expect.nat(state.bytes.size()).equal(0);
+        expect.nat(state.index).equal(0);
+        expect.nat8(state.bits).equal(0x00);
+        expect.nat8(state.bitMask).equal(0x00)
+      }
+    );
+    await test(
+      "cryptoFromState() creates AsyncRandom with proper state reference",
+      func() : async () {
+        let state = Random.emptyState();
+        let _random = Random.cryptoFromState(state);
+
+        // The AsyncRandom should use the same state object
+        // We can verify the state is properly initialized
+        expect.nat(state.bytes.size()).equal(0);
+        expect.nat(state.index).equal(0)
+      }
+    );
+    await test(
+      "Multiple AsyncRandom instances can share the same state",
+      func() : async () {
+        let state = Random.emptyState();
+        let _random1 = Random.cryptoFromState(state);
+        let _random2 = Random.cryptoFromState(state);
+
+        // Both should reference the same state object
+        // This tests that state sharing works correctly
+        expect.nat(state.bytes.size()).equal(0);
+        expect.nat(state.index).equal(0)
+      }
+    );
+    await test(
+      "AsyncRandom state independence with separate states",
+      func() : async () {
+        let state1 = Random.emptyState();
+        let state2 = Random.emptyState();
+        let _random1 = Random.cryptoFromState(state1);
+        let _random2 = Random.cryptoFromState(state2);
+
+        // States should be independent objects
+        expect.nat(state1.index).equal(state2.index); // Both start at 0
+        expect.nat(state1.bytes.size()).equal(state2.bytes.size()); // Both start empty
+
+        // But they should be different objects (we can't directly test object identity,
+        // but we can test that modifying one doesn't affect the other)
+        state1.index := 5;
+        expect.bool(state1.index != state2.index).isTrue();
+        expect.nat(state2.index).equal(0)
+      }
+    )
+  }
+);
+
+await suite(
+  "AsyncRandom state management (synchronous tests)",
+  func() : async () {
+    // Helper function to create a mock async generator for testing
+    func mockAsyncGenerator(bytes : [Nat8]) : () -> async* Blob {
+      func() : async* Blob {
+        Blob.fromArray(bytes)
+      }
+    };
+
+    await test(
+      "AsyncRandom creation with mock generator",
+      func() : async () {
+        let state = Random.emptyState();
+        let mockBytes : [Nat8] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
+
+        // Create AsyncRandom with mock generator
+        let _random = Random.AsyncRandom(state, mockAsyncGenerator(mockBytes));
+
+        // Verify initial state
+        expect.nat(state.bytes.size()).equal(0);
+        expect.nat(state.index).equal(0);
+
+        // Note: Cannot test actual async methods here due to test framework limitations
+      }
+    );
+    await test(
+      "State modifications are persistent across AsyncRandom instances",
+      func() : async () {
+        let state = Random.emptyState();
+
+        // Manually simulate what would happen after some random generation
+        state.bytes := [100, 200, 50, 75];
+        state.index := 2;
+        state.bits := 0x55;
+        state.bitMask := 0x20;
+
+        // Create new AsyncRandom with modified state
+        let _random = Random.cryptoFromState(state);
+
+        // Verify state persists
+        expect.nat(state.bytes.size()).equal(4);
+        expect.nat(state.index).equal(2);
+        expect.nat8(state.bits).equal(0x55);
+        expect.nat8(state.bitMask).equal(0x20);
+
+        // Further simulate state advancement
+        state.index := 3;
+        expect.nat(state.index).equal(3)
+      }
+    );
+    await test(
+      "State reuse scenario simulation",
+      func() : async () {
+        let state = Random.emptyState();
+
+        // Simulate canister upgrade scenario
+        // Before upgrade: some random generation has occurred
+        state.bytes := [10, 20, 30, 40, 50, 60, 70, 80];
+        state.index := 3;
+        state.bits := 0xAA;
+        state.bitMask := 0x08;
+
+        // After upgrade: create new AsyncRandom with persisted state
+        let _random = Random.cryptoFromState(state);
+
+        // State should be exactly as it was before upgrade
+        expect.nat(state.bytes.size()).equal(8);
+        expect.nat(state.index).equal(3);
+        expect.nat8(state.bits).equal(0xAA);
+        expect.nat8(state.bitMask).equal(0x08);
+
+        // The bytes at current index should be accessible
+        expect.nat8(state.bytes[state.index]).equal(40); // bytes[3] == 40
+      }
+    );
+    await test(
+      "Edge case: state with exhausted bytes",
+      func() : async () {
+        let state = Random.emptyState();
+
+        // Simulate state where all bytes have been consumed
+        state.bytes := [1, 2, 3, 4];
+        state.index := 4; // Beyond array bounds, should trigger new byte generation
+
+        let _random = Random.cryptoFromState(state);
+
+        // State should reflect the exhausted condition
+        expect.nat(state.bytes.size()).equal(4);
+        expect.nat(state.index).equal(4);
+        expect.bool(state.index >= state.bytes.size()).isTrue()
+      }
+    );
+    await test(
+      "Bit mask cycling simulation",
+      func() : async () {
+        let state = Random.emptyState();
+
+        // Test various bit mask states that would occur during bool() generation
+        let bitMaskStates : [Nat8] = [0x00, 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01];
+
+        for (mask in bitMaskStates.vals()) {
+          state.bitMask := mask;
+          state.bits := 0xFF; // All bits set for testing
+
+          let _random = Random.cryptoFromState(state);
+
+          // Verify state is set correctly
+          expect.nat8(state.bitMask).equal(mask);
+          expect.nat8(state.bits).equal(0xFF)
+        }
+      }
+    );
+    await test(
+      "AsyncRandom byte exhaustion simulation",
+      func() : async () {
+        let state = Random.emptyState();
+        let mockBytes1 : [Nat8] = [1, 2];
+        let mockBytes2 : [Nat8] = [3, 4, 5];
+
+        // Create a generator that alternates between two different byte arrays
+        var callCount = 0;
+        func alternatingGenerator() : async* Blob {
+          callCount += 1;
+          if (callCount % 2 == 1) {
+            Blob.fromArray(mockBytes1)
+          } else {
+            Blob.fromArray(mockBytes2)
+          }
+        };
+
+        let _random = Random.AsyncRandom(state, alternatingGenerator);
+
+        // Verify initial state setup
+        expect.nat(state.bytes.size()).equal(0);
+        expect.nat(state.index).equal(0);
+
+        // Note: Cannot test actual byte generation here due to async limitations
+        // This test verifies the setup is correct for async operations
+      }
+    )
+  }
+);
+
+await suite(
+  "AsyncRandom",
+  func() : async () {
+    // Helper function to create deterministic mock generator for testing
+    func deterministicMockGenerator(seed : Nat8) : () -> async* Blob {
+      var counter = seed;
+      func() : async* Blob {
+        let bytes : [Nat8] = Array.tabulate<Nat8>(16, func(i) {
+          counter := Nat8.fromNat((Nat8.toNat(counter) + 1) % 256);
+          counter
+        });
+        Blob.fromArray(bytes)
+      }
+    };
+
+    await test(
+      "bool() method produces boolean values",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(0));
+
+        // Test multiple bool() calls
+        let results : [Bool] = [
+          await* random.bool(),
+          await* random.bool(),
+          await* random.bool(),
+          await* random.bool(),
+          await* random.bool()
+        ];
+
+        // All results should be valid booleans (this is always true in Motoko)
+        // Just verify we can call the method without errors
+        expect.nat(results.size()).equal(5);
+
+        // Test that bool() advances state
+        let initialIndex = state.index;
+        let _ = await* random.bool();
+        // Note: Due to bit masking, bool() may not always advance byte index
+        // but it should advance bit consumption
+        expect.bool(state.bitMask != 0x00 or state.index > initialIndex).isTrue()
+      }
+    );
+
+    await test(
+      "nat8() method produces Nat8 values in correct range",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(10));
+
+        // Test multiple nat8() calls
+        let results : [Nat8] = [
+          await* random.nat8(),
+          await* random.nat8(),
+          await* random.nat8(),
+          await* random.nat8(),
+          await* random.nat8()
+        ];
+
+        // Verify all results are valid Nat8 values (always true, but test execution)
+        expect.nat(results.size()).equal(5);
+        
+        // Verify state advancement
+        expect.nat(state.index).equal(5);
+        expect.nat(state.bytes.size()).equal(16); // First generator call should populate 16 bytes
+      }
+    );
+
+    await test(
+      "nat8() with known deterministic sequence",
+      func() : async () {
+        let state = Random.emptyState();
+        // Create generator that produces predictable bytes
+        func predictableGenerator() : async* Blob {
+          Blob.fromArray([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16])
+        };
+        let random = Random.AsyncRandom(state, predictableGenerator);
+
+        // Test first few values
+        expect.nat8(await* random.nat8()).equal(1);
+        expect.nat8(await* random.nat8()).equal(2);
+        expect.nat8(await* random.nat8()).equal(3);
+        expect.nat8(await* random.nat8()).equal(4);
+        expect.nat8(await* random.nat8()).equal(5);
+      }
+    );
+
+    await test(
+      "nat64() method produces Nat64 values",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(42));
+
+        // Test multiple nat64() calls
+        let results : [Nat64] = [
+          await* random.nat64(),
+          await* random.nat64(),
+          await* random.nat64()
+        ];
+
+        // Verify all results are valid (no specific range check needed for full Nat64)
+        expect.nat(results.size()).equal(3);
+        
+        // Each nat64() should consume 8 bytes, but generator produces 16 bytes at a time
+        // So after 3 calls: first 2 calls consume 16 bytes, 3rd call triggers new generator call and consumes 8 more
+        expect.nat(state.index).equal(8); // 3rd call consumed 8 bytes from fresh 16-byte batch
+      }
+    );
+
+    await test(
+      "nat64() with predictable bytes produces expected values",
+      func() : async () {
+        let state = Random.emptyState();
+        // Generator that produces bytes 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...
+        func sequentialGenerator() : async* Blob {
+          let bytes = Array.tabulate<Nat8>(16, func(i) { Nat8.fromNat(i) });
+          Blob.fromArray(bytes)
+        };
+        let random = Random.AsyncRandom(state, sequentialGenerator);
+
+        let result = await* random.nat64();
+        
+        // Expected: bytes [0,1,2,3,4,5,6,7] combined as big-endian Nat64
+        // = 0x0001020304050607
+        let expected : Nat64 = 
+          (0 << 56) | (1 << 48) | (2 << 40) | (3 << 32) | 
+          (4 << 24) | (5 << 16) | (6 << 8) | 7;
+        expect.nat64(result).equal(expected)
+      }
+    );
+
+    await test(
+      "nat64Range() returns values within specified range",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(123));
+
+        let from : Nat64 = 100;
+        let toExclusive : Nat64 = 200;
+
+        // Test multiple calls
+        for (_ in Nat.range(0, 20)) {
+          let val = await* random.nat64Range(from, toExclusive);
+          expect.bool(val >= from).isTrue();
+          expect.bool(val < toExclusive).isTrue()
+        }
+      }
+    );
+
+    await test(
+      "nat64Range() with single value range",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(0));
+
+        let from : Nat64 = 42;
+        let toExclusive : Nat64 = 43;
+
+        // Should always return the single possible value
+        for (_ in Nat.range(0, 10)) {
+          let val = await* random.nat64Range(from, toExclusive);
+          expect.nat64(val).equal(from)
+        }
+      }
+    );
+
+    await test(
+      "natRange() returns values within specified range",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(200));
+
+        let from = 50;
+        let toExclusive = 150;
+
+        // Test multiple calls
+        for (_ in Nat.range(0, 20)) {
+          let val = await* random.natRange(from, toExclusive);
+          expect.bool(val >= from).isTrue();
+          expect.bool(val < toExclusive).isTrue()
+        }
+      }
+    );
+
+    await test(
+      "natRange() with single value range",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(0));
+
+        let from = 99;
+        let toExclusive = 100;
+
+        // Should always return the single possible value
+        for (_ in Nat.range(0, 10)) {
+          let val = await* random.natRange(from, toExclusive);
+          expect.nat(val).equal(from)
+        }
+      }
+    );
+
+    await test(
+      "intRange() returns values within specified range",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(77));
+
+        let from = -100;
+        let toExclusive = 100;
+
+        // Test multiple calls
+        for (_ in Nat.range(0, 20)) {
+          let val = await* random.intRange(from, toExclusive);
+          expect.bool(val >= from).isTrue();
+          expect.bool(val < toExclusive).isTrue()
+        }
+      }
+    );
+
+    await test(
+      "intRange() with negative range",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(55));
+
+        let from = -500;
+        let toExclusive = -400;
+
+        // Test multiple calls
+        for (_ in Nat.range(0, 15)) {
+          let val = await* random.intRange(from, toExclusive);
+          expect.bool(val >= from).isTrue();
+          expect.bool(val < toExclusive).isTrue()
+        }
+      }
+    );
+
+    await test(
+      "intRange() with positive range",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(33));
+
+        let from = 1000;
+        let toExclusive = 2000;
+
+        // Test multiple calls
+        for (_ in Nat.range(0, 15)) {
+          let val = await* random.intRange(from, toExclusive);
+          expect.bool(val >= from).isTrue();
+          expect.bool(val < toExclusive).isTrue()
+        }
+      }
+    );
+
+    await test(
+      "intRange() with single value range",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(0));
+
+        let from = -50;
+        let toExclusive = -49;
+
+        // Should always return the single possible value
+        for (_ in Nat.range(0, 10)) {
+          let val = await* random.intRange(from, toExclusive);
+          expect.int(val).equal(from)
+        }
+      }
+    );
+
+    await test(
+      "State persistence across multiple generators",
+      func() : async () {
+        let state = Random.emptyState();
+        
+        // First generator
+        let random1 = Random.AsyncRandom(state, deterministicMockGenerator(10));
+        let val1 = await* random1.nat8();
+        let firstIndex = state.index;
+        
+        // Second generator with same state
+        let random2 = Random.AsyncRandom(state, deterministicMockGenerator(20));
+        let val2 = await* random2.nat8();
+        
+        // State should continue from where first left off
+        expect.nat(state.index).equal(firstIndex + 1);
+        
+        // Values should be different since we're continuing from advanced state
+        expect.bool(val1 != val2).isTrue()
+      }
+    );
+
+    await test(
+      "Generator refill behavior when bytes exhausted",
+      func() : async () {
+        let state = Random.emptyState();
+        
+        // Create generator that produces small chunks
+        var generatorCallCount = 0;
+        func smallChunkGenerator() : async* Blob {
+          generatorCallCount += 1;
+          if (generatorCallCount == 1) {
+            Blob.fromArray([100, 101]) // Only 2 bytes
+          } else {
+            Blob.fromArray([200, 201, 202, 203]) // 4 bytes
+          }
+        };
+        
+        let random = Random.AsyncRandom(state, smallChunkGenerator);
+        
+        // Consume first 2 bytes
+        expect.nat8(await* random.nat8()).equal(100);
+        expect.nat8(await* random.nat8()).equal(101);
+        expect.nat(generatorCallCount).equal(1);
+        
+        // This should trigger second generator call
+        expect.nat8(await* random.nat8()).equal(200);
+        expect.nat(generatorCallCount).equal(2);
+        
+        // Continue with remaining bytes from second call
+        expect.nat8(await* random.nat8()).equal(201);
+        expect.nat8(await* random.nat8()).equal(202);
+        expect.nat8(await* random.nat8()).equal(203);
+        expect.nat(generatorCallCount).equal(2); // Still 2, no new call needed
+      }
+    );
+
+    await test(
+      "Mixed method calls maintain state consistency",
+      func() : async () {
+        let state = Random.emptyState();
+        let random = Random.AsyncRandom(state, deterministicMockGenerator(128));
+
+        // Mix different method calls
+        let _bool1 = await* random.bool();
+        let _nat8_1 = await* random.nat8();
+        let _nat64_1 = await* random.nat64();
+        let _natRange1 = await* random.natRange(0, 100);
+        let _intRange1 = await* random.intRange(-50, 50);
+        let _bool2 = await* random.bool();
+
+        // State should have advanced appropriately
+        // Each nat8() call advances index by 1
+        // Each nat64() call advances index by 8
+        // Each range call uses nat64() internally, so advances by 8 (or more due to rejection sampling)
+        // bool() may or may not advance index depending on bit mask state
+        
+        expect.nat(state.index).greater(0); // Should have advanced
+        expect.nat(state.bytes.size()).greater(0); // Should have bytes loaded
+      }
+    )
+  }
+);
+
+await suite(
+  "AsyncRandom cryptographic randomness integration",
+  func() : async () {
+    await test(
+      "crypto() creates working AsyncRandom",
+      func() : async () {
+        let random = Random.crypto();
+        
+        // Test that we can call methods (actual randomness will vary)
+        let _bool = await* random.bool();
+        let _nat8 = await* random.nat8();
+        let _nat64 = await* random.nat64();
+        
+        // Just verify calls complete successfully
+        expect.bool(true).isTrue()
+      }
+    );
+
+    await test(
+      "cryptoFromState() with persistent state",
+      func() : async () {
+        let state = Random.emptyState();
+        let random1 = Random.cryptoFromState(state);
+        
+        // Generate some values to modify state
+        let _val1 = await* random1.nat8();
+        let _val2 = await* random1.nat8();
+        
+        // Create new instance with same state
+        let random2 = Random.cryptoFromState(state);
+        let _val3 = await* random2.nat8();
+        
+        // State should have been modified by previous calls
+        expect.bool(state.index > 0).isTrue();
+        expect.bool(state.bytes.size() > 0).isTrue();
+        
+        // Just verify the call works (actual value will be cryptographically random)
+        expect.bool(true).isTrue()
+      }
+    );
+
+    await test(
+      "Multiple crypto instances with shared state",
+      func() : async () {
+        let state = Random.emptyState();
+        let random1 = Random.cryptoFromState(state);
+        let random2 = Random.cryptoFromState(state);
+        
+        // Both instances should share the same state
+        let _val1 = await* random1.nat8();
+        let index1 = state.index;
+        
+        let _val2 = await* random2.nat8();
+        let index2 = state.index;
+        
+        // Second call should advance from where first left off
+        expect.bool(index2 > index1).isTrue()
+      }
+    )
+  }
+)

--- a/test/Random.async.test.mo
+++ b/test/Random.async.test.mo
@@ -9,6 +9,12 @@ import { suite; test; expect } = "mo:test/async";
 await suite(
   "Random.emptyState() and AsyncRandom state management",
   func() : async () {
+    func mockAsyncGenerator(bytes : [Nat8]) : () -> async* Blob {
+      func() : async* Blob {
+        Blob.fromArray(bytes)
+      }
+    };
+
     await test(
       "emptyState() creates proper initial state",
       func() : async () {
@@ -24,25 +30,39 @@ await suite(
       "cryptoFromState() creates AsyncRandom with proper state reference",
       func() : async () {
         let state = Random.emptyState();
-        let _random = Random.cryptoFromState(state);
+        let random = Random.cryptoFromState(state);
 
-        // The AsyncRandom should use the same state object
-        // We can verify the state is properly initialized
         expect.nat(state.bytes.size()).equal(0);
-        expect.nat(state.index).equal(0)
+        expect.nat(state.index).equal(0);
+
+        let _val1 = await* random.nat8();
+        let _val2 = await* random.nat8();
+
+        expect.nat(state.bytes.size()).greater(0);
+        expect.nat(state.index).greater(0)
       }
     );
     await test(
       "Multiple AsyncRandom instances can share the same state",
       func() : async () {
         let state = Random.emptyState();
-        let _random1 = Random.cryptoFromState(state);
-        let _random2 = Random.cryptoFromState(state);
+        let random1 = Random.cryptoFromState(state);
+        let random2 = Random.cryptoFromState(state);
 
-        // Both should reference the same state object
-        // This tests that state sharing works correctly
         expect.nat(state.bytes.size()).equal(0);
-        expect.nat(state.index).equal(0)
+        expect.nat(state.index).equal(0);
+
+        let _val1 = await* random1.nat8();
+        let index1 = state.index;
+
+        let _val2 = await* random2.nat8();
+        let index2 = state.index;
+
+        expect.nat(index2).greater(index1);
+        expect.nat(state.bytes.size()).greater(0);
+
+        let _bool1 = await* random1.bool();
+        let _bool2 = await* random2.bool()
       }
     );
     await test(
@@ -50,68 +70,57 @@ await suite(
       func() : async () {
         let state1 = Random.emptyState();
         let state2 = Random.emptyState();
-        let _random1 = Random.cryptoFromState(state1);
-        let _random2 = Random.cryptoFromState(state2);
+        let random1 = Random.cryptoFromState(state1);
+        let random2 = Random.cryptoFromState(state2);
 
-        // States should be independent objects
         expect.nat(state1.index).equal(state2.index);
         expect.nat(state1.bytes.size()).equal(state2.bytes.size());
 
-        // But they should be different objects (we can't directly test object identity,
-        // but we can test that modifying one doesn't affect the other)
         state1.index := 5;
         expect.nat(state1.index).equal(5);
-        expect.nat(state2.index).equal(0)
-      }
-    )
-  }
-);
+        expect.nat(state2.index).equal(0);
 
-await suite(
-  "AsyncRandom state management (synchronous tests)",
-  func() : async () {
-    // Helper function to create a mock async generator for testing
-    func mockAsyncGenerator(bytes : [Nat8]) : () -> async* Blob {
-      func() : async* Blob {
-        Blob.fromArray(bytes)
-      }
-    };
+        let _val1 = await* random1.nat8();
+        let _val2 = await* random2.nat8();
 
+        expect.nat(state1.index).greater(0);
+        expect.nat(state2.index).greater(0);
+        expect.nat(state1.bytes.size()).greater(0);
+        expect.nat(state2.bytes.size()).greater(0);
+
+        let range1 = await* random1.natRange(10, 20);
+        let range2 = await* random2.natRange(10, 20);
+
+        expect.nat(range1).greaterOrEqual(10);
+        expect.nat(range1).less(20);
+        expect.nat(range2).greaterOrEqual(10);
+        expect.nat(range2).less(20)
+      }
+    );
     await test(
       "AsyncRandom creation with mock generator",
       func() : async () {
         let state = Random.emptyState();
         let mockBytes : [Nat8] = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16];
 
-        let _random = Random.AsyncRandom(state, mockAsyncGenerator(mockBytes));
+        let random = Random.AsyncRandom(state, mockAsyncGenerator(mockBytes));
 
         expect.nat(state.bytes.size()).equal(0);
         expect.nat(state.index).equal(0);
 
-        // Note: Cannot test actual async methods here due to test framework limitations
-      }
-    );
-    await test(
-      "State modifications are persistent across AsyncRandom instances",
-      func() : async () {
-        let state = Random.emptyState();
+        let val1 = await* random.nat8();
+        let val2 = await* random.nat8();
+        let val3 = await* random.nat8();
 
-        // Manually simulate what would happen after some random generation
-        state.bytes := [100, 200, 50, 75];
-        state.index := 2;
-        state.bits := 0x55;
-        state.bitMask := 0x20;
+        expect.nat(state.bytes.size()).greater(0);
+        expect.nat(state.index).greater(0);
 
-        let _random = Random.cryptoFromState(state);
+        expect.nat8(val1).equal(1);
+        expect.nat8(val2).equal(2);
+        expect.nat8(val3).equal(3);
 
-        expect.nat(state.bytes.size()).equal(4);
-        expect.nat(state.index).equal(2);
-        expect.nat8(state.bits).equal(0x55);
-        expect.nat8(state.bitMask).equal(0x20);
-
-        // Further simulate state advancement
-        state.index := 3;
-        expect.nat(state.index).equal(3)
+        let nat64Val = await* random.nat64();
+        expect.nat64(nat64Val).greater(0)
       }
     );
     await test(
@@ -119,24 +128,33 @@ await suite(
       func() : async () {
         let state = Random.emptyState();
 
-        // Simulate canister upgrade scenario
-        // Before upgrade: some random generation has occurred
         state.bytes := [10, 20, 30, 40, 50, 60, 70, 80];
         state.index := 3;
         state.bits := 0xAA;
         state.bitMask := 0x08;
 
-        // After upgrade: create new AsyncRandom with persisted state
-        let _random = Random.cryptoFromState(state);
+        let random = Random.cryptoFromState(state);
 
-        // State should be exactly as it was before upgrade
         expect.nat(state.bytes.size()).equal(8);
         expect.nat(state.index).equal(3);
         expect.nat8(state.bits).equal(0xAA);
         expect.nat8(state.bitMask).equal(0x08);
 
-        // The bytes at current index should be accessible
-        expect.nat8(state.bytes[state.index]).equal(40); // bytes[3] == 40
+        expect.nat8(state.bytes[state.index]).equal(40);
+
+        let nextVal = await* random.nat8();
+        expect.nat8(nextVal).equal(40);
+
+        let afterVal = await* random.nat8();
+        expect.nat8(afterVal).equal(50);
+
+        let _boolVal = await* random.bool();
+
+        expect.nat(state.index).greater(3);
+
+        let rangeVal = await* random.intRange(-10, 10);
+        expect.int(rangeVal).greaterOrEqual(-10);
+        expect.int(rangeVal).less(10)
       }
     );
     await test(
@@ -144,62 +162,28 @@ await suite(
       func() : async () {
         let state = Random.emptyState();
 
-        // Simulate state where all bytes have been consumed
         state.bytes := [1, 2, 3, 4];
-        state.index := 4; // Beyond array bounds, should trigger new byte generation
+        state.index := 4;
 
-        let _random = Random.cryptoFromState(state);
+        let random = Random.cryptoFromState(state);
 
-        // State should reflect the exhausted condition
         expect.nat(state.bytes.size()).equal(4);
         expect.nat(state.index).equal(4);
-        expect.nat(state.index).equal(state.bytes.size())
-      }
-    );
-    await test(
-      "Bit mask cycling simulation",
-      func() : async () {
-        let state = Random.emptyState();
+        expect.nat(state.index).equal(state.bytes.size());
 
-        // Test various bit mask states that would occur during bool() generation
-        let bitMaskStates : [Nat8] = [0x00, 0x80, 0x40, 0x20, 0x10, 0x08, 0x04, 0x02, 0x01];
+        let _val1 = await* random.nat8();
+        let _val2 = await* random.nat8();
 
-        for (mask in bitMaskStates.vals()) {
-          state.bitMask := mask;
-          state.bits := 0xFF; // All bits set for testing
+        expect.nat(state.bytes.size()).greater(4);
+        expect.nat(state.index).greater(0);
 
-          let _random = Random.cryptoFromState(state);
+        let _boolVal = await* random.bool();
+        let nat64Val = await* random.nat64();
+        let rangeVal = await* random.natRange(100, 200);
 
-          expect.nat8(state.bitMask).equal(mask);
-          expect.nat8(state.bits).equal(0xFF)
-        }
-      }
-    );
-    await test(
-      "AsyncRandom byte exhaustion simulation",
-      func() : async () {
-        let state = Random.emptyState();
-        let mockBytes1 : [Nat8] = [1, 2];
-        let mockBytes2 : [Nat8] = [3, 4, 5];
-
-        // Create a generator that alternates between two different byte arrays
-        var callCount = 0;
-        func alternatingGenerator() : async* Blob {
-          callCount += 1;
-          if (callCount % 2 == 1) {
-            Blob.fromArray(mockBytes1)
-          } else {
-            Blob.fromArray(mockBytes2)
-          }
-        };
-
-        let _random = Random.AsyncRandom(state, alternatingGenerator);
-
-        expect.nat(state.bytes.size()).equal(0);
-        expect.nat(state.index).equal(0);
-
-        // Note: Cannot test actual byte generation here due to async limitations
-        // This test verifies the setup is correct for async operations
+        expect.nat64(nat64Val).greater(0);
+        expect.nat(rangeVal).greaterOrEqual(100);
+        expect.nat(rangeVal).less(200)
       }
     )
   }
@@ -208,7 +192,6 @@ await suite(
 await suite(
   "AsyncRandom",
   func() : async () {
-    // Helper function to create deterministic mock generator for testing
     func deterministicMockGenerator(seed : Nat8) : () -> async* Blob {
       var counter = seed;
       func() : async* Blob {
@@ -239,11 +222,9 @@ await suite(
 
         expect.nat(results.size()).equal(5);
 
-        // Test that bool() advances state
         let initialIndex = state.index;
         let initialBitMask = state.bitMask;
         let _ = await* random.bool();
-        // State should be modified after bool() call (either index or bitMask advances)
         expect.bool(state.index > initialIndex or state.bitMask != initialBitMask).isTrue()
       }
     );
@@ -263,9 +244,8 @@ await suite(
         ];
 
         expect.nat(results.size()).equal(5);
-
         expect.nat(state.index).equal(5);
-        expect.nat(state.bytes.size()).equal(16); // First generator call should populate 16 bytes
+        expect.nat(state.bytes.size()).equal(16)
       }
     );
 
@@ -299,10 +279,7 @@ await suite(
         ];
 
         expect.nat(results.size()).equal(3);
-
-        // Each nat64() should consume 8 bytes, but generator produces 16 bytes at a time
-        // So after 3 calls: first 2 calls consume 16 bytes, 3rd call triggers new generator call and consumes 8 more
-        expect.nat(state.index).equal(8); // 3rd call consumed 8 bytes from fresh 16-byte batch
+        expect.nat(state.index).equal(8)
       }
     );
 
@@ -310,7 +287,6 @@ await suite(
       "nat64() with predictable bytes produces expected values",
       func() : async () {
         let state = Random.emptyState();
-        // Generator that produces bytes 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, ...
         func sequentialGenerator() : async* Blob {
           let bytes = Array.tabulate<Nat8>(16, func(i) { Nat8.fromNat(i) });
           Blob.fromArray(bytes)
@@ -319,166 +295,30 @@ await suite(
 
         let result = await* random.nat64();
 
-        // Expected: bytes [0,1,2,3,4,5,6,7] combined as big-endian Nat64
-        // = 0x0001020304050607
         let expected : Nat64 = (0 << 56) | (1 << 48) | (2 << 40) | (3 << 32) | (4 << 24) | (5 << 16) | (6 << 8) | 7;
         expect.nat64(result).equal(expected)
       }
     );
 
     await test(
-      "nat64Range() returns values within specified range",
+      "Range methods return values within specified range",
       func() : async () {
         let state = Random.emptyState();
         let random = Random.AsyncRandom(state, deterministicMockGenerator(123));
 
-        let from : Nat64 = 100;
-        let toExclusive : Nat64 = 200;
-
-        for (_ in Nat.range(0, 20)) {
-          let val = await* random.nat64Range(from, toExclusive);
-          expect.bool(val >= from).isTrue();
-          expect.bool(val < toExclusive).isTrue()
-        }
-      }
-    );
-
-    await test(
-      "nat64Range() with single value range",
-      func() : async () {
-        let state = Random.emptyState();
-        let random = Random.AsyncRandom(state, deterministicMockGenerator(0));
-
-        let from : Nat64 = 42;
-        let toExclusive : Nat64 = 43;
-
         for (_ in Nat.range(0, 10)) {
-          let val = await* random.nat64Range(from, toExclusive);
-          expect.nat64(val).equal(from)
+          let nat64Val = await* random.nat64Range(100, 200);
+          expect.nat64(nat64Val).greaterOrEqual(100);
+          expect.nat64(nat64Val).less(200);
+
+          let natVal = await* random.natRange(50, 150);
+          expect.nat(natVal).greaterOrEqual(50);
+          expect.nat(natVal).less(150);
+
+          let intVal = await* random.intRange(-100, 100);
+          expect.int(intVal).greaterOrEqual(-100);
+          expect.int(intVal).less(100)
         }
-      }
-    );
-
-    await test(
-      "natRange() returns values within specified range",
-      func() : async () {
-        let state = Random.emptyState();
-        let random = Random.AsyncRandom(state, deterministicMockGenerator(200));
-
-        let from = 50;
-        let toExclusive = 150;
-
-        for (_ in Nat.range(0, 20)) {
-          let val = await* random.natRange(from, toExclusive);
-          expect.bool(val >= from).isTrue();
-          expect.bool(val < toExclusive).isTrue()
-        }
-      }
-    );
-
-    await test(
-      "natRange() with single value range",
-      func() : async () {
-        let state = Random.emptyState();
-        let random = Random.AsyncRandom(state, deterministicMockGenerator(0));
-
-        let from = 99;
-        let toExclusive = 100;
-
-        for (_ in Nat.range(0, 10)) {
-          let val = await* random.natRange(from, toExclusive);
-          expect.nat(val).equal(from)
-        }
-      }
-    );
-
-    await test(
-      "intRange() returns values within specified range",
-      func() : async () {
-        let state = Random.emptyState();
-        let random = Random.AsyncRandom(state, deterministicMockGenerator(77));
-
-        let from = -100;
-        let toExclusive = 100;
-
-        for (_ in Nat.range(0, 20)) {
-          let val = await* random.intRange(from, toExclusive);
-          expect.bool(val >= from).isTrue();
-          expect.bool(val < toExclusive).isTrue()
-        }
-      }
-    );
-
-    await test(
-      "intRange() with negative range",
-      func() : async () {
-        let state = Random.emptyState();
-        let random = Random.AsyncRandom(state, deterministicMockGenerator(55));
-
-        let from = -500;
-        let toExclusive = -400;
-
-        for (_ in Nat.range(0, 15)) {
-          let val = await* random.intRange(from, toExclusive);
-          expect.bool(val >= from).isTrue();
-          expect.bool(val < toExclusive).isTrue()
-        }
-      }
-    );
-
-    await test(
-      "intRange() with positive range",
-      func() : async () {
-        let state = Random.emptyState();
-        let random = Random.AsyncRandom(state, deterministicMockGenerator(33));
-
-        let from = 1000;
-        let toExclusive = 2000;
-
-        for (_ in Nat.range(0, 15)) {
-          let val = await* random.intRange(from, toExclusive);
-          expect.bool(val >= from).isTrue();
-          expect.bool(val < toExclusive).isTrue()
-        }
-      }
-    );
-
-    await test(
-      "intRange() with single value range",
-      func() : async () {
-        let state = Random.emptyState();
-        let random = Random.AsyncRandom(state, deterministicMockGenerator(0));
-
-        let from = -50;
-        let toExclusive = -49;
-
-        for (_ in Nat.range(0, 10)) {
-          let val = await* random.intRange(from, toExclusive);
-          expect.int(val).equal(from)
-        }
-      }
-    );
-
-    await test(
-      "State persistence across multiple generators",
-      func() : async () {
-        let state = Random.emptyState();
-
-        // First generator
-        let random1 = Random.AsyncRandom(state, deterministicMockGenerator(10));
-        let val1 = await* random1.nat8();
-        let firstIndex = state.index;
-
-        // Second generator with same state
-        let random2 = Random.AsyncRandom(state, deterministicMockGenerator(20));
-        let val2 = await* random2.nat8();
-
-        // State should continue from where first left off
-        expect.nat(state.index).equal(firstIndex + 1);
-
-        // Values should be different since we're continuing from advanced state
-        expect.nat8(val1).equal(11); // First byte from deterministicMockGenerator(10)
-        expect.nat8(val2).equal(12); // Second byte from same generator state
       }
     );
 
@@ -491,28 +331,25 @@ await suite(
         func smallChunkGenerator() : async* Blob {
           generatorCallCount += 1;
           if (generatorCallCount == 1) {
-            Blob.fromArray([100, 101]) // Only 2 bytes
+            Blob.fromArray([100, 101])
           } else {
-            Blob.fromArray([200, 201, 202, 203]) // 4 bytes
+            Blob.fromArray([200, 201, 202, 203])
           }
         };
 
         let random = Random.AsyncRandom(state, smallChunkGenerator);
 
-        // Consume first 2 bytes
         expect.nat8(await* random.nat8()).equal(100);
         expect.nat8(await* random.nat8()).equal(101);
         expect.nat(generatorCallCount).equal(1);
 
-        // This should trigger second generator call
         expect.nat8(await* random.nat8()).equal(200);
         expect.nat(generatorCallCount).equal(2);
 
-        // Continue with remaining bytes from second call
         expect.nat8(await* random.nat8()).equal(201);
         expect.nat8(await* random.nat8()).equal(202);
         expect.nat8(await* random.nat8()).equal(203);
-        expect.nat(generatorCallCount).equal(2); // Still 2, no new call needed
+        expect.nat(generatorCallCount).equal(2)
       }
     );
 
@@ -522,7 +359,6 @@ await suite(
         let state = Random.emptyState();
         let random = Random.AsyncRandom(state, deterministicMockGenerator(128));
 
-        // Mix different method calls
         let _bool1 = await* random.bool();
         let _nat8_1 = await* random.nat8();
         let _nat64_1 = await* random.nat64();
@@ -530,14 +366,8 @@ await suite(
         let _intRange1 = await* random.intRange(-50, 50);
         let _bool2 = await* random.bool();
 
-        // State should have advanced appropriately
-        // Each nat8() call advances index by 1
-        // Each nat64() call advances index by 8
-        // Each range call uses nat64() internally, so advances by 8 (or more due to rejection sampling)
-        // bool() may or may not advance index depending on bit mask state
-
-        expect.nat(state.index).greater(0); // Should have advanced
-        expect.nat(state.bytes.size()).greater(0); // Should have bytes loaded
+        expect.nat(state.index).greater(0);
+        expect.nat(state.bytes.size()).greater(0)
       }
     )
   }
@@ -551,7 +381,6 @@ await suite(
       func() : async () {
         let random = Random.crypto();
 
-        // Test that we can call methods (actual randomness will vary)
         let _bool = await* random.bool();
         let _nat8 = await* random.nat8();
         let _nat64 = await* random.nat64()
@@ -570,7 +399,6 @@ await suite(
         let random2 = Random.cryptoFromState(state);
         let _val3 = await* random2.nat8();
 
-        // State should have been modified by previous calls
         expect.nat(state.index).greater(0);
         expect.nat(state.bytes.size()).greater(0)
       }
@@ -583,14 +411,12 @@ await suite(
         let random1 = Random.cryptoFromState(state);
         let random2 = Random.cryptoFromState(state);
 
-        // Both instances should share the same state
         let _val1 = await* random1.nat8();
         let index1 = state.index;
 
         let _val2 = await* random2.nat8();
         let index2 = state.index;
 
-        // Second call should advance from where first left off
         expect.nat(index2).greater(index1)
       }
     )


### PR DESCRIPTION
This PR adds missing functions to the `AsyncRandom` class which existed in `Random`. 

Context: [developer forum post](https://forum.dfinity.org/t/motoko-base-library-changes/39766/61).