### PR TITLE
Breaking: fix `Int.fromText()` corner cases from original base library

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,7 @@
 # Next
 
 * Perf: Made `Nat.toText()` slightly more performant (#358).
+* Change `Int.fromText()` to return `null` for `"+"` and `"-"` instead of `?0` (#365).
 
 ## 0.6.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Next
 
 * Perf: Made `Nat.toText()` slightly more performant (#358).
-* Change `Int.fromText()` to return `null` for `"+"` and `"-"` instead of `?0` (#365).
+* Change `Int.fromText()` to return `null` instead of `?0` for `"+"` and `"-"` (#365).
 
 ## 0.6.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,7 +1,7 @@
 # Next
 
 * Perf: Made `Nat.toText()` slightly more performant (#358).
-* Change `Int.fromText()` to return `null` instead of `?0` for `"+"` and `"-"` (#365).
+* **Breaking:** Adjust `Int.fromText()` to return `null` instead of `?0` for `"+"` and `"-"` (#365).
 
 ## 0.6.0
 

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -87,18 +87,23 @@ module {
     var n = 0;
     var isFirst = true;
     var isNegative = false;
+    var hasDigits = false;
     for (c in text.chars()) {
       if (isFirst and c == '+') {
         // Skip character
       } else if (isFirst and c == '-') {
         isNegative := true
       } else if (Char.isDigit(c)) {
+        hasDigits := true;
         let charAsNat = Prim.nat32ToNat(Prim.charToNat32(c) -% Prim.charToNat32('0'));
         n := n * 10 + charAsNat
       } else {
         return null
       };
       isFirst := false
+    };
+    if (not hasDigits) {
+      return null
     };
     ?(if (isNegative) { -n } else { n })
   };

--- a/test/Int.test.mo
+++ b/test/Int.test.mo
@@ -1000,4 +1000,94 @@ do {
   assert Array.fromIter(Int.rangeByInclusive(1, 2, 0)) == [];
   assert Array.fromIter(Int.rangeByInclusive(2, 1, 1)) == [];
   assert Array.fromIter(Int.rangeByInclusive(1, 2, -1)) == []
-}
+};
+
+/* --------------------------------------- */
+
+run(
+  suite(
+    "fromText",
+    [
+      test(
+        "positive number",
+        Int.fromText("1234"),
+        M.equals(T.optional<Int>(T.intTestable, ?1234))
+      ),
+      test(
+        "negative number",
+        Int.fromText("-1234"),
+        M.equals(T.optional<Int>(T.intTestable, ?(-1234)))
+      ),
+      test(
+        "zero",
+        Int.fromText("0"),
+        M.equals(T.optional<Int>(T.intTestable, ?0))
+      ),
+      test(
+        "positive with plus sign",
+        Int.fromText("+1234"),
+        M.equals(T.optional<Int>(T.intTestable, ?1234))
+      ),
+      test(
+        "negative zero",
+        Int.fromText("-0"),
+        M.equals(T.optional<Int>(T.intTestable, ?0))
+      ),
+      test(
+        "positive zero",
+        Int.fromText("+0"),
+        M.equals(T.optional<Int>(T.intTestable, ?0))
+      ),
+      test(
+        "empty string",
+        Int.fromText(""),
+        M.equals(T.optional<Int>(T.intTestable, null))
+      ),
+      test(
+        "plus sign only",
+        Int.fromText("+"),
+        M.equals(T.optional<Int>(T.intTestable, null))
+      ),
+      test(
+        "minus sign only",
+        Int.fromText("-"),
+        M.equals(T.optional<Int>(T.intTestable, null))
+      ),
+      test(
+        "invalid character",
+        Int.fromText("12a34"),
+        M.equals(T.optional<Int>(T.intTestable, null))
+      ),
+      test(
+        "leading invalid character",
+        Int.fromText("a1234"),
+        M.equals(T.optional<Int>(T.intTestable, null))
+      ),
+      test(
+        "trailing invalid character",
+        Int.fromText("1234a"),
+        M.equals(T.optional<Int>(T.intTestable, null))
+      ),
+      test(
+        "multiple signs",
+        Int.fromText("+-1234"),
+        M.equals(T.optional<Int>(T.intTestable, null))
+      ),
+      test(
+        "space in number",
+        Int.fromText("12 34"),
+        M.equals(T.optional<Int>(T.intTestable, null))
+      ),
+      test(
+        "large number",
+        Int.fromText(largeNumberText),
+        M.equals(T.optional<Int>(T.intTestable, ?largeNumber))
+      ),
+      test(
+        "negative large number",
+        Int.fromText("-" # largeNumberText),
+        M.equals(T.optional<Int>(T.intTestable, ?(-largeNumber)))
+      )
+    ]
+  )
+)


### PR DESCRIPTION
Adjusts `Int.fromText()` to return `null` instead of `?0` for `"+"` and `"-"` (resolves #362).

This is a breaking change which would behave differently compared to the original base library. 

PR for including this in the migration guide: https://github.com/dfinity/motoko/pull/5388
