### PR TITLE
Breaking: return `?T` from `List.get()`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -5,6 +5,7 @@
 * Add `uniform64()`, `nat64()`, `natRange()`, and `intRange()` to `AsyncRandom` class (#360).
 * Fix corner case in `sliceToArray()` (#364).
 * **Breaking:** Adjust `Int.fromText()` to return `null` instead of `?0` for `"+"` and `"-"` (#365).
+* **Breaking:** Change `List.get()` to return `?T` instead of `T` for consistency.
 
 ## 0.6.0
 

--- a/src/List.mo
+++ b/src/List.mo
@@ -556,7 +556,7 @@ module {
       }
     ) {
       case (?result) return result;
-      case (_) Prim.trap "List index out of bounds in getUnsafe"
+      case (_) Prim.trap "List.getUnsafe(): index out of bounds"
     }
   };
 
@@ -597,7 +597,7 @@ module {
     let (a, b) = locate(index);
     if (a < list.blockIndex or a == list.blockIndex and b < list.elementIndex) {
       list.blocks[a][b] := ?value
-    } else Prim.trap "List index out of bounds in put"
+    } else Prim.trap "List.put(): index out of bounds"
   };
 
   /// Sorts the elements in the list according to `compare`.

--- a/src/pure/Set.mo
+++ b/src/pure/Set.mo
@@ -1126,9 +1126,9 @@ module {
       func buildFromSortedHelper(l : Nat, r : Nat, depth : Nat) : Tree<V> {
         if (l + 1 == r) {
           if (depth == maxDepth) {
-            return #red(#leaf, List.get(buf, l), #leaf)
+            return #red(#leaf, List.getUnsafe(buf, l), #leaf)
           } else {
-            return #black(#leaf, List.get(buf, l), #leaf)
+            return #black(#leaf, List.getUnsafe(buf, l), #leaf)
           }
         };
         if (l >= r) {
@@ -1137,7 +1137,7 @@ module {
         let m = (l + r) / 2;
         return #black(
           buildFromSortedHelper(l, m, depth + 1),
-          List.get(buf, m),
+          List.getUnsafe(buf, m),
           buildFromSortedHelper(m + 1, r, depth + 1)
         )
       };

--- a/test/List.test.mo
+++ b/test/List.test.mo
@@ -919,7 +919,7 @@ func testNew(n : Nat) : Bool {
 
 func testInit(n : Nat) : Bool {
   let vec = List.repeat<Nat>(1, n);
-  List.size(vec) == n and (n == 0 or (List.get(vec, 0) == 1 and List.get(vec, n - 1 : Nat) == 1))
+  List.size(vec) == n and (n == 0 or (List.get(vec, 0) == ?1 and List.get(vec, n - 1 : Nat) == ?1))
 };
 
 func testAdd(n : Nat) : Bool {
@@ -935,10 +935,17 @@ func testAdd(n : Nat) : Bool {
   };
 
   for (i in Nat.range(0, n)) {
-    let value = List.get(vec, i);
-    if (value != i) {
-      Debug.print("Value mismatch at index " # Nat.toText(i) # ": expected " # Nat.toText(i) # ", got " # Nat.toText(value));
-      return false
+    switch (List.get(vec, i)) {
+      case (?value) {
+        if (value != i) {
+          Debug.print("Value mismatch at index " # Nat.toText(i) # ": expected " # Nat.toText(i) # ", got " # Nat.toText(value));
+          return false
+        }
+      };
+      case null {
+        Debug.print("Unexpected null at index " # Nat.toText(i));
+        return false
+      }
     }
   };
 
@@ -954,10 +961,17 @@ func testAddAll(n : Nat) : Bool {
     return false
   };
   for (i in Nat.range(0, n)) {
-    let value = List.get(vec, n + i);
-    if (value != 1) {
-      Debug.print("Value mismatch at index " # Nat.toText(i) # ": expected " # Nat.toText(1) # ", got " # Nat.toText(value));
-      return false
+    switch (List.get(vec, n + i)) {
+      case (?value) {
+        if (value != 1) {
+          Debug.print("Value mismatch at index " # Nat.toText(i) # ": expected " # Nat.toText(1) # ", got " # Nat.toText(value));
+          return false
+        }
+      };
+      case null {
+        Debug.print("Unexpected null at index " # Nat.toText(i));
+        return false
+      }
     }
   };
   true
@@ -998,10 +1012,17 @@ func testGet(n : Nat) : Bool {
   let vec = List.fromArray<Nat>(Array.tabulate<Nat>(n, func(i) = i + 1));
 
   for (i in Nat.range(1, n + 1)) {
-    let value = List.get(vec, i - 1 : Nat);
-    if (value != i) {
-      Debug.print("get: Mismatch at index " # Nat.toText(i) # ": expected " # Nat.toText(i) # ", got " # Nat.toText(value));
-      return false
+    switch (List.get(vec, i - 1 : Nat)) {
+      case (?value) {
+        if (value != i) {
+          Debug.print("get: Mismatch at index " # Nat.toText(i) # ": expected " # Nat.toText(i) # ", got " # Nat.toText(value));
+          return false
+        }
+      };
+      case null {
+        Debug.print("get: Unexpected null at index " # Nat.toText(i));
+        return false
+      }
     }
   };
 
@@ -1046,7 +1067,7 @@ func testPut(n : Nat) : Bool {
     true
   } else {
     List.put(vec, n - 1 : Nat, 100);
-    List.get(vec, n - 1 : Nat) == 100
+    List.get(vec, n - 1 : Nat) == ?100
   }
 };
 


### PR DESCRIPTION
Addresses feedback about inconsistent return types between `get()` functions across data structures.

Original usages of `List.get()` can be wrapped in `Option.unwrap()` for equivalent functionality.
