### PR TITLE
fix: Inconsistent handing of empty iterators in `Int.mo` and `Nat.mo`, and tests for `{Int, Nat}.rangeInclusive()`.

### DIFF
--- a/src/Int.mo
+++ b/src/Int.mo
@@ -499,7 +499,6 @@ module {
   /// ```
   public func rangeInclusive(from : Int, to : Int) : Iter.Iter<Int> {
     if (from > to) {
-      // Needs tests.
       Iter.empty()
     } else {
       object {

--- a/src/Int.mo
+++ b/src/Int.mo
@@ -406,15 +406,19 @@ module {
   /// assert iter.next() == null; // empty iterator
   /// ```
   public func range(fromInclusive : Int, toExclusive : Int) : Iter.Iter<Int> {
-    object {
-      var n = fromInclusive;
-      public func next() : ?Int {
-        if (n >= toExclusive) {
-          null
-        } else {
-          let result = n;
-          n += 1;
-          ?result
+    if (fromInclusive >= toExclusive) {
+      Iter.empty()
+    } else {
+      object {
+        var n = fromInclusive;
+        public func next() : ?Int {
+          if (n >= toExclusive) {
+            null
+          } else {
+            let result = n;
+            n += 1;
+            ?result
+          }
         }
       }
     }
@@ -494,15 +498,20 @@ module {
   /// assert iter.next() == null; // empty iterator
   /// ```
   public func rangeInclusive(from : Int, to : Int) : Iter.Iter<Int> {
-    object {
-      var n = from;
-      public func next() : ?Int {
-        if (n > to) {
-          null
-        } else {
-          let result = n;
-          n += 1;
-          ?result
+    if (from > to) {
+      // Needs tests.
+      Iter.empty()
+    } else {
+      object {
+        var n = from;
+        public func next() : ?Int {
+          if (n > to) {
+            null
+          } else {
+            let result = n;
+            n += 1;
+            ?result
+          }
         }
       }
     }

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -374,15 +374,21 @@ module {
   /// let iter = Nat.range(4, 1);
   /// assert iter.next() == null; // empty iterator
   /// ```
-  public func range(fromInclusive : Nat, toExclusive : Nat) : Iter.Iter<Nat> = object {
-    var n = fromInclusive;
-    public func next() : ?Nat {
-      if (n >= toExclusive) {
-        return null
-      };
-      let current = n;
-      n += 1;
-      ?current
+  public func range(fromInclusive : Nat, toExclusive : Nat) : Iter.Iter<Nat> {
+    if (fromInclusive >= toExclusive) {
+      Iter.empty()
+    } else {
+      object {
+        var n = fromInclusive;
+        public func next() : ?Nat {
+          if (n >= toExclusive) {
+            return null
+          };
+          let current = n;
+          n += 1;
+          ?current
+        }
+      }
     }
   };
 
@@ -408,7 +414,7 @@ module {
   ///
   /// If `step` is 0 or if the iteration would not progress towards the bound, returns an empty iterator.
   public func rangeBy(fromInclusive : Nat, toExclusive : Nat, step : Int) : Iter.Iter<Nat> {
-    if (step == 0) {
+    if (step == 0 or (step > 0 and fromInclusive >= toExclusive) or (step < 0 and fromInclusive <= toExclusive)) {
       Iter.empty()
     } else if (step > 0) {
       object {
@@ -461,15 +467,22 @@ module {
   /// let iter = Nat.rangeInclusive(3, 1);
   /// assert iter.next() == null; // empty iterator
   /// ```
-  public func rangeInclusive(from : Nat, to : Nat) : Iter.Iter<Nat> = object {
-    var n = from;
-    public func next() : ?Nat {
-      if (n > to) {
-        return null
-      };
-      let current = n;
-      n += 1;
-      ?current
+  public func rangeInclusive(from : Nat, to : Nat) : Iter.Iter<Nat> {
+    if (from > to) {
+      // Needs tests.
+      Iter.empty()
+    } else {
+      object {
+        var n = from;
+        public func next() : ?Nat {
+          if (n > to) {
+            return null
+          };
+          let current = n;
+          n += 1;
+          ?current
+        }
+      }
     }
   };
 

--- a/src/Nat.mo
+++ b/src/Nat.mo
@@ -469,7 +469,6 @@ module {
   /// ```
   public func rangeInclusive(from : Nat, to : Nat) : Iter.Iter<Nat> {
     if (from > to) {
-      // Needs tests.
       Iter.empty()
     } else {
       object {

--- a/test/Int.test.mo
+++ b/test/Int.test.mo
@@ -980,6 +980,16 @@ do {
 };
 
 do {
+  Debug.print("rangeInclusive()");
+
+  assert Array.fromIter(Int.rangeInclusive(0, 2)) == [0, 1, 2];
+  assert Array.fromIter(Int.rangeInclusive(-2, 2)) == [-2, -1, 0, 1, 2];
+  assert Array.fromIter(Int.rangeInclusive(1, 1)) == [1];
+  assert Array.fromIter(Int.rangeInclusive(1, 0)) == [];
+  assert Array.fromIter(Int.rangeInclusive(1, -1)) == []
+};
+
+do {
   Debug.print("rangeByInclusive()");
 
   assert Array.fromIter(Int.rangeByInclusive(1, 7, 2)) == [1, 3, 5, 7];

--- a/test/Nat.test.mo
+++ b/test/Nat.test.mo
@@ -55,7 +55,11 @@ test(
     assert Array.fromIter(Nat.rangeBy(3, 1, -2)) == [3];
     assert Array.fromIter(Nat.rangeBy(1, 3, -1)) == [];
     assert Array.fromIter(Nat.rangeBy(0, 1, 0)) == [];
-    assert Array.fromIter(Nat.rangeBy(1, 0, 0)) == []
+    assert Array.fromIter(Nat.rangeBy(1, 0, 0)) == [];
+
+    assert Array.fromIter(Nat.rangeBy(4, 4, 1)) == [];
+    assert Array.fromIter(Nat.rangeBy(3, 4, 1)) == [3];
+    assert Array.fromIter(Nat.rangeBy(4, 3, -1)) == [4]
   }
 );
 

--- a/test/Nat.test.mo
+++ b/test/Nat.test.mo
@@ -64,6 +64,18 @@ test(
 );
 
 test(
+  "rangeInclusive",
+  func() {
+    assert Array.fromIter(Nat.rangeInclusive(0, 2)) == [0, 1, 2];
+    assert Array.fromIter(Nat.rangeInclusive(1, 2)) == [1, 2];
+    assert Array.fromIter(Nat.rangeInclusive(1, 1)) == [1];
+    assert Array.fromIter(Nat.rangeInclusive(1, 0)) == [];
+    assert Array.fromIter(Nat.rangeInclusive(0, 0)) == [0];
+    assert Array.fromIter(Nat.rangeInclusive(0, 1)) == [0, 1]
+  }
+);
+
+test(
   "rangeByInclusive",
   func() {
     assert Array.fromIter(Nat.rangeByInclusive(1, 7, 2)) == [1, 3, 5, 7];


### PR DESCRIPTION
Range functions in `Int.mo` and `Nat.mo` have to return an empty iterator in some cases. Sometimes this is done explicitly (by returning an empty iterator), and sometimes implicitly (by relying on the underlying logic to resolve to an empty iterator). Most of the time, this is done using the former method, but there are a few instances where the latter is used (somewhat inconsistently):

- `Nat.range()` (but not `Nat*.range()`)
- `Nat.rangeBy()`
- `Nat.rangeInclusive()` (`Nat*.rangeInclusive()`)
- `Int.range()` (but not `Int*.range()`) 
- `Int.rangeInclusive()`(but not `Int*.rangeInclusive()`)

This PR fixes this inconsistency (applying the explicit approach to the above). This PR also adds more unit tests where appropriate, notably tests for `{Int, Nat}.rangeInclusive()`, which there weren't any so far.

This PR addresses https://github.com/dfinity/motoko-core/issues/369.